### PR TITLE
Added missing deps

### DIFF
--- a/buildprep
+++ b/buildprep
@@ -165,9 +165,9 @@ daemon () {
     case $installer in
 	apk)
 	    $install build-base python3 busybox			 # basic tools
-	    $install bison python3-dev linux-headers		 # build
-	    $install openssl-dev libseccomp-dev gpsd-dev	 # build
-	    $install py3-gpsd libc-dev linux-lts-dev		 # build
+	    $install bison python3-dev linux-headers libbsd-dev	 # build
+	    $install openssl-dev libseccomp-dev gpsd-dev libbsd	 # build
+	    $install py3-gpsd libc-dev linux-lts-dev libexec-dev # build
             $install avahi-dev avahi-compat-libdns_sd libcap-dev # optional build
 	    $do find ./ \( -type d -name .git -prune \) -o -type f | xargs sed -i 's/env python/env python3/g'
 	    # With just python3 installed, there is no "python".

--- a/buildprep
+++ b/buildprep
@@ -167,7 +167,7 @@ daemon () {
 	    $install build-base python3 busybox			 # basic tools
 	    $install bison python3-dev linux-headers libbsd-dev	 # build
 	    $install openssl-dev libseccomp-dev gpsd-dev libbsd	 # build
-	    $install py3-gpsd libc-dev linux-lts-dev libexec-dev # build
+	    $install py3-gpsd linux-lts-dev libexec-dev 	 # build
             $install avahi-dev avahi-compat-libdns_sd libcap-dev # optional build
 	    $do find ./ \( -type d -name .git -prune \) -o -type f | xargs sed -i 's/env python/env python3/g'
 	    # With just python3 installed, there is no "python".

--- a/buildprep
+++ b/buildprep
@@ -164,7 +164,7 @@ daemon () {
     # Prerequisites to build the daemon: bison, pps-tools, service libraries
     case $installer in
 	apk)
-	    $install build-base python3 busybox asciidoc	# basic tools
+	    $install build-base python3 busybox			# basic tools
 	    $install bison python${PYVERS}-dev linux-headers	# deps
 	    $install openssl-dev libcap-dev libseccomp-dev	# deps
 	    $install py3-gpsd libc-dev linux-lts-dev		# deps

--- a/buildprep
+++ b/buildprep
@@ -164,11 +164,11 @@ daemon () {
     # Prerequisites to build the daemon: bison, pps-tools, service libraries
     case $installer in
 	apk)
-	    $install build-base python3 busybox			# basic tools
-	    $install bison python3-dev linux-headers		# build
-	    $install openssl-dev libseccomp-dev gpsd-dev	# build
-	    $install py3-gpsd libc-dev linux-lts-dev		# build
-            $install avahi-dev libcap-dev			# optional build
+	    $install build-base python3 busybox			 # basic tools
+	    $install bison python3-dev linux-headers		 # build
+	    $install openssl-dev libseccomp-dev gpsd-dev	 # build
+	    $install py3-gpsd libc-dev linux-lts-dev		 # build
+            $install avahi-dev avahi-compat-libdns_sd libcap-dev # optional build
 	    $do find ./ \( -type d -name .git -prune \) -o -type f | xargs sed -i 's/env python/env python3/g'
 	    # With just python3 installed, there is no "python".
 	    # It acts up when symlinked, so change all #!'s to python3

--- a/buildprep
+++ b/buildprep
@@ -165,9 +165,13 @@ daemon () {
     case $installer in
 	apk)
 	    $install build-base python3 busybox			# basic tools
-	    $install bison python${PYVERS}-dev linux-headers	# deps
-	    $install openssl-dev libcap-dev libseccomp-dev	# deps
-	    $install py3-gpsd libc-dev linux-lts-dev		# deps
+	    $install bison python3-dev linux-headers		# build
+	    $install openssl-dev libseccomp-dev gpsd-dev	# build
+	    $install py3-gpsd libc-dev linux-lts-dev		# build
+            $install avahi-dev libcap-dev			# optional build
+	    $do find ./ \( -type d -name .git -prune \) -o -type f | xargs sed -i 's/env python/env python3/g'
+	    # With just python3 installed, there is no "python".
+	    # It acts up when symlinked, so change all #!'s to python3
 	    ;;
 	apt)
 	    $install build-essential			# Build environment

--- a/buildprep
+++ b/buildprep
@@ -52,7 +52,7 @@ done
 
 # Some Python 2 packages (e.g python-devel, python-psutils) conventionally have
 # Python 3 equivalents with a python3 prefix.  Compute the correct value for the
-# infix based on system Python.  This eill start to be significant after Python 2
+# infix based on system Python.  This will start to be significant after Python 2
 # EOLs at the beginning of 2020.
 PYVERS=`python --version 2>&1 | sed -n -e '/Python \([0-9]\).*/s//\1/p'`
 if [ "$PYVERS" = "2" ]
@@ -164,11 +164,10 @@ daemon () {
     # Prerequisites to build the daemon: bison, pps-tools, service libraries
     case $installer in
 	apk)
-	    $install build-base python                  # basic tools
-	    $install bison python${PYVERS}-dev linux-headers
-	    $install openssl-dev libcap-dev libseccomp-dev
-	    # probably needs more, but this builds
-	    # can't find timepps.h: gpsd and chrony have their own ??
+	    $install build-base python3 busybox asciidoc	# basic tools
+	    $install bison python${PYVERS}-dev linux-headers	# deps
+	    $install openssl-dev libcap-dev libseccomp-dev	# deps
+	    $install py3-gpsd libc-dev linux-lts-dev		# deps
 	    ;;
 	apt)
 	    $install build-essential			# Build environment


### PR DESCRIPTION
# probably needs more, but this builds
# can't find timepps.h: gpsd and chrony have their own ??

yes, you are correct. gpsd-dev has the file: https://git.alpinelinux.org/aports/tree/main/gpsd/APKBUILD?h=3.12-stable (Line 20)

python should be python3
py3-gpsd is also needed.
And a few other things....