### PR TITLE
Use bytes instead of characters for hashlib

### DIFF
--- a/contrib/ntpheat
+++ b/contrib/ntpheat
@@ -75,7 +75,7 @@ while True:
     delta = temp_gate - temp
     if 0 < delta:
         # heat it up
-        m.update("Nobody inspects the spammish repetition")
+        m.update(b"Nobody inspects the spammish repetition")
     else:
         cnt = max_cnt
         # cools off slower than it heats up.


### PR DESCRIPTION
Feeding bytes not characters to hashlib to make it compatible with newer versions (see for example https://python.readthedocs.io/fr/hack-in-language/library/hashlib.html)