### PR TITLE
Update sandbox for glibc 2.34/kernel 5.14

### DIFF
--- a/ntpd/ntp_sandbox.c
+++ b/ntpd/ntp_sandbox.c
@@ -349,6 +349,7 @@ int scmp_sc[] = {
 	SCMP_SYS(lseek),
 	SCMP_SYS(membarrier),	/* Needed on Alpine 3.11.3 */
 	SCMP_SYS(munmap),
+	SCMP_SYS(newfstatat),
 	SCMP_SYS(open),
 #ifdef __NR_openat
 	SCMP_SYS(openat),	/* SUSE */
@@ -452,7 +453,6 @@ int scmp_sc[] = {
 #endif
 #if defined(__aarch64__)
 	SCMP_SYS(faccessat),
-	SCMP_SYS(newfstatat),
 	SCMP_SYS(renameat),
 	SCMP_SYS(linkat),
 	SCMP_SYS(unlinkat),

--- a/ntpd/ntp_sandbox.c
+++ b/ntpd/ntp_sandbox.c
@@ -451,7 +451,7 @@ int scmp_sc[] = {
 	/* gentoo 64-bit and 32-bit, Intel and Arm use mmap */
 	SCMP_SYS(mmap),
 #endif
-#if defined(__aarch64__)
+#if defined(__aarch64__) || defined(__riscv)
 	SCMP_SYS(faccessat),
 	SCMP_SYS(renameat),
 	SCMP_SYS(linkat),


### PR DESCRIPTION
Current Yocto poky with seccomp enabled fails to run ntpd on (at least) x86-64 and riscv64 because of missing syscalls in the filter set. 