### PR TITLE
Support  ecdhcurves list TLS Option

### DIFF
--- a/docs/includes/nts-commands.adoc
+++ b/docs/includes/nts-commands.adoc
@@ -4,7 +4,7 @@ The following command controls NTS authentication. It overrides
 normal TLS protocol negotiation, which is not usually necessary.
 
 [[nts]]
-+nts+ [enable|disable] [+mintls+ _version_] [+maxtls+ _version_] [+tlsciphersuites+ _name_]
++nts+ [enable|disable] [+mintls+ _version_] [+maxtls+ _version_] [+tlsciphersuites+ _name_] [+tlsecdhcurves+ _name_]
 
 The options are as follows:
 

--- a/docs/includes/nts-commands.adoc
+++ b/docs/includes/nts-commands.adoc
@@ -55,6 +55,10 @@ The options are as follows:
    An OpenSSL ciphersuite list to configure the allowed ciphersuites for
    TLS 1.3.  A single NULL cipher disables encryption and use of certificates.
 
++tlsecdhcurves+ _string_::
+   An OpenSSL ecdhcurves list to configure the allowed ecdhcurves for
+   TLS 1.3.  A single NULL ecdhcurves disables encryption and use of certificates.
+
 +aead+ _string_::
    Specify the crypto algorithm to be used on the wire.  The choices
    come from RFC 5297.  The only options supported are AES_SIV_CMAC_256,

--- a/include/nts.h
+++ b/include/nts.h
@@ -150,7 +150,7 @@ struct ntsconfig_t {
 	const char * mintls;	/* minimum TLS version allowed */
 	const char * maxtls;	/* maximum TLS version allowed */
 	const char *tlsciphersuites;/* allowed TLS 1.3 ciphersuites */
-	const char *tlsecdhcurves;
+	const char *tlsecdhcurves; /* allowed ecdhcurves list*/
 	const char *cert;	/* file holding server certificate key */
 	const char *key;	/* file holding server private key */
 	const char *KI;		/* file holding K/I for making cookies */

--- a/include/nts.h
+++ b/include/nts.h
@@ -150,6 +150,7 @@ struct ntsconfig_t {
 	const char * mintls;	/* minimum TLS version allowed */
 	const char * maxtls;	/* maximum TLS version allowed */
 	const char *tlsciphersuites;/* allowed TLS 1.3 ciphersuites */
+	const char *tlsecdhcurves;
 	const char *cert;	/* file holding server certificate key */
 	const char *key;	/* file holding server private key */
 	const char *KI;		/* file holding K/I for making cookies */

--- a/include/nts2.h
+++ b/include/nts2.h
@@ -20,6 +20,7 @@
 bool nts_load_certificate(SSL_CTX *ctx);
 void nts_reload_certificate(SSL_CTX *ctx);
 bool nts_load_ciphers(SSL_CTX *ctx);
+bool nts_load_ecdhcurves(SSL_CTX *ctx);
 bool nts_load_versions(SSL_CTX *ctx);
 
 int nts_ssl_read(SSL *ssl, uint8_t *buff, int buff_length);

--- a/ntpd/keyword-gen.c
+++ b/ntpd/keyword-gen.c
@@ -204,6 +204,7 @@ struct key_tok ntp_keywords[] = {
 { "mintls",		T_Mintls,		FOLLBY_TOKEN },
 { "maxtls",		T_Maxtls,		FOLLBY_TOKEN },
 { "tlsciphersuites",	T_Tlsciphersuites,	FOLLBY_STRING },
+{ "tlsecdhcurves",	T_Tlsecdhcurves,	FOLLBY_STRING },
 };
 
 typedef struct big_scan_state_tag {

--- a/ntpd/ntp_config.c
+++ b/ntpd/ntp_config.c
@@ -1974,6 +1974,9 @@ config_nts(
 		case T_Tlsciphersuites:
 			ntsconfig.tlsciphersuites = estrdup(nts->value.s);
 			break;
+		case T_Tlsecdhcurves:
+			ntsconfig.tlsecdhcurves = estrdup(nts->value.s);
+			break;
 #endif
 		}
 	}

--- a/ntpd/ntp_parser.y
+++ b/ntpd/ntp_parser.y
@@ -212,6 +212,7 @@
 %token	<Integer>	T_Tinker
 %token	<Integer>	T_Tlsciphers
 %token	<Integer>	T_Tlsciphersuites
+%token	<Integer>	T_Tlsecdhcurves
 %token	<Integer>	T_Tos
 %token	<Integer>	T_True
 %token	<Integer>	T_Trustedkey
@@ -1143,6 +1144,7 @@ nts_string_option_keyword
 	|	T_Key
 	|	T_Tlsciphers
 	|	T_Tlsciphersuites
+	|   T_Tlsecdhcurves
 	|	T_Maxtls
 	|	T_Mintls
 

--- a/ntpd/nts.c
+++ b/ntpd/nts.c
@@ -192,9 +192,9 @@ bool nts_load_ciphers(SSL_CTX *ctx) {
 }
 
 bool nts_load_ecdhcurves(SSL_CTX *ctx) {
-	/* SSL_CTX_set1_curves_list ignores typos or curves it doesn't support.
+	/* SSL_CTX_set1_groups_list ignores typos or curves it doesn't support.
 	 * There is no SSL_CTX_get_curves_list, so we can't easily read back
-	 * the ciphers to see what it took.
+	 * the ecdhcurves to see what it took.
 	 * We could make a dummy SSL, read the list, then free it.
 	 */
 	if (NULL != ntsconfig.tlsecdhcurves) {

--- a/ntpd/nts.c
+++ b/ntpd/nts.c
@@ -34,6 +34,7 @@ struct ntsconfig_t ntsconfig = {
 	.mintls = NULL,
 	.maxtls = NULL,
 	.tlsciphersuites = NULL,
+	.tlsecdhcurves = NULL,
 	.cert = NULL,
 	.key = NULL,
 	.KI = NULL,
@@ -190,7 +191,22 @@ bool nts_load_ciphers(SSL_CTX *ctx) {
 	return true;
 }
 
-
+bool nts_load_ecdhcurves(SSL_CTX *ctx) {
+	/* SSL_CTX_set1_curves_list ignores typos or curves it doesn't support.
+	 * There is no SSL_CTX_get_curves_list, so we can't easily read back
+	 * the ciphers to see what it took.
+	 * We could make a dummy SSL, read the list, then free it.
+	 */
+	if (NULL != ntsconfig.tlsecdhcurves) {
+		if (1 != SSL_CTX_set1_groups_list(ctx, ntsconfig.tlsecdhcurves)) {
+			msyslog(LOG_ERR, "NTS: troubles setting ecdhcurves.");
+			return false;
+		} else {
+			msyslog(LOG_INFO, "NTS: set ecdhcurves.");
+		}
+	}
+	return true;
+}
 static struct stat certfile_stat;
 
 void nts_reload_certificate(SSL_CTX *ctx) {

--- a/ntpd/nts_client.c
+++ b/ntpd/nts_client.c
@@ -225,6 +225,7 @@ SSL_CTX* make_ssl_client_ctx(const char * filename) {
 
 	ok &= nts_load_versions(ctx);
 	ok &= nts_load_ciphers(ctx);
+	ok &= nts_load_ecdhcurves(ctx);
 	ok &= nts_set_cert_search(ctx, filename);
 
 	if (!ok) {

--- a/ntpd/nts_server.c
+++ b/ntpd/nts_server.c
@@ -110,7 +110,7 @@ bool nts_server_init(void) {
 
 	ok &= nts_load_versions(server_ctx);
 	ok &= nts_load_ciphers(server_ctx);
-
+	ok &= nts_load_ecdhcurves(server_ctx);
 	if (!ok) {
 		msyslog(LOG_ERR, "NTSs: Disabling NTS-KE server");
 		SSL_CTX_free(server_ctx);

--- a/ntpd/nts_server.c
+++ b/ntpd/nts_server.c
@@ -111,6 +111,7 @@ bool nts_server_init(void) {
 	ok &= nts_load_versions(server_ctx);
 	ok &= nts_load_ciphers(server_ctx);
 	ok &= nts_load_ecdhcurves(server_ctx);
+
 	if (!ok) {
 		msyslog(LOG_ERR, "NTSs: Disabling NTS-KE server");
 		SSL_CTX_free(server_ctx);


### PR DESCRIPTION
Hi, the TLS option for ecdhcurves has been added to the repository. I determined that the ecdhcurves field in the hello packet has been set after analyzing and capturing the packet.