### PR TITLE
Fix ntpdig.py

### DIFF
--- a/ntpclients/ntpdig.py
+++ b/ntpclients/ntpdig.py
@@ -55,24 +55,25 @@ except ImportError as e:
 # The one new option in this version is -p, borrowed from ntpdate.
 
 
-def read_append(s, packets, packet, sockaddr):
+def read_append(s, packets, server):
     d, a = s.recvfrom(1024)
-    if debug >= 2:
+    if debug >= 3:
+        log("receiving from %s" % server)
         ntp.packet.dump_hex_printable(d)
     if credentials:
         if not ntp.packet.Authenticator.have_mac(d):
             if debug:
-                log("no MAC on reply from %s" % packet.hostname)
+                log("no MAC on reply from %s" % server)
         if not credentials.verify_mac(d, packet_end=48, mac_begin=48):
             packet.trusted = False
             log("MAC verification on reply from %s failed"
-                % sockaddr[0])
+                % a[0])
         elif debug:
             log("MAC verification on reply from %s succeeded"
-                % sockaddr[0])
+                % a[0])
     pkt = ntp.packet.SyncPacket(d)
     pkt.hostname = server
-    pkt.resolved = sockaddr[0]
+    pkt.resolved = a[0]
     packets.append(pkt)
     return packets
 
@@ -85,17 +86,19 @@ def queryhost(server, concurrent, timeout=5, port=123):
                                       socket.IPPROTO_UDP)
     except socket.gaierror as e:
         log("lookup of %s failed, errno %d = %s" % (server, e.args[0], e.args[1]))
-        return []
+        return [] # not callable
     sockets = []
     packets = []
     request = ntp.packet.SyncPacket()
     request.transmit_timestamp = ntp.packet.SyncPacket.posix_to_ntp(
         time.time())
     packet = request.flatten()
-    needgap = (len(iptuples) > 1) and (gap > 0)
+    needgap = (len(iptuples) > 1) and (gap > 0) and (not concurrent)
     firstloop = True
     for (family, socktype, proto, canonname, sockaddr) in iptuples:
         if needgap and not firstloop:
+            if debug >= 2:
+                log("Sleeping %dms" % (gap * 1000))
             time.sleep(gap)
         if firstloop:
             firstloop = False
@@ -125,24 +128,31 @@ def queryhost(server, concurrent, timeout=5, port=123):
             if debug:
                 log("socket error on transmission: %s" % e)
             continue
-        if debug >= 2:
+        if debug >= 3:
             log("Sent to %s:" % (sockaddr[0],))
             ntp.packet.dump_hex_printable(packet)
         if concurrent:
             sockets.append(s)
         else:
-            r, _, _ = select.select([s], [], [], timeout)
-            if r:
-                read_append(s, packets, packet, sockaddr)
-        while sockets:
-            r, _, _ = select.select(sockets, [], [], timeout)
-            if not r:
-                return packets
-            for s in sockets:
-                read_append(s, packets, packet, sockaddr)
-                sockets.remove(s)
-    return packets
+            ready, _, _ = select.select([s], [], [], timeout)
+            if ready:
+                read_append(s, packets, server)
 
+    if concurrent:
+        def closure():
+            nonlocal sockets, server
+            packets = []
+            while sockets:
+                ready, _, _ = select.select(sockets, [], [], timeout)
+                if not ready:
+                    return packets
+                for s in ready:
+                    read_append(s, packets, server)
+                    sockets.remove(s)
+            return packets;
+        return closure
+    else:
+        return packets
 
 def clock_select(packets):
     "Select the pick-of-the-litter clock from the samples we've got."
@@ -192,7 +202,11 @@ def clock_select(packets):
         return filtered
 
     # Sort by stratum and other figures of merit
-    filtered.sort(key=lambda s: (s.stratum, s.synchd(), s.root_delay))
+    filtered.sort(key=lambda s: (int(s.stratum/4), abs(s.adjust()), s.synchd(), s.root_delay))
+
+    if debug:
+        for pk in filtered:
+           report(pk, json)
 
     # Return the best
     return filtered[:1]
@@ -255,6 +269,7 @@ USAGE:  ntpdig [-<flag> [<val>] | --<name>[{=| }<val>]]...
    -j no  json            Use JSON output format
    -l Str logfile         Log to specified logfile
                                  - prohibits the option 'syslog'
+   -M yes steplimit       Maximum offset for slew in milliseconds
    -p yes samples         Number of samples to take (default 1)
    -S no  step            Set (step) the time with clock_settime()
                                  - prohibits the option 'step'
@@ -299,7 +314,7 @@ if __name__ == '__main__':
         authkey = None
         concurrent_hosts = []
         debug = 0
-        gap = .05
+        gap = 2000
         json = False
         keyfile = None
         steplimit = 0       # Default is intentionally zero
@@ -339,7 +354,7 @@ if __name__ == '__main__':
                         raise SystemExit(1)
                 elif switch in ("-M", "--steplimit"):
                     errmsg = "Error: -M parameter '%s' not a number\n"
-                    steplimit = ntp.util.safeargcast(val, int, errmsg, usage)
+                    steplimit = ntp.util.safeargcast(val, float, errmsg, usage)
                     steplimit /= 1000.0
                 elif switch in ("-p", "--samples"):
                     errmsg = "Error: -p parameter '%s' not a number\n"
@@ -371,7 +386,7 @@ if __name__ == '__main__':
             sys.stderr.write(usage)
             raise SystemExit(1)
 
-        gap /= 1000  # convert to milliseconds
+        gap /= 1000  # convert from milliseconds
 
         credentials = keyid = keytype = passwd = None
         try:
@@ -392,7 +407,7 @@ if __name__ == '__main__':
             sys.stderr.write("-a option requires -k.\n")
             raise SystemExit(1)
 
-        if not arguments:
+        if not arguments and not concurrent_hosts:
             arguments = ["localhost"]
 
         if replay:
@@ -406,17 +421,28 @@ if __name__ == '__main__':
             firstloop = True
             for s in range(samples):
                 if needgap and not firstloop:
+                    if debug >= 2:
+                        log("Sleeping %dms before sample %d" % (gap * 1000, s))
                     time.sleep(gap)
                 if firstloop:
                     firstloop = False
+                results = []
                 for server in concurrent_hosts:
                     try:
-                        returned += queryhost(server=server,
+                        results.append(queryhost(server=server,
                                               concurrent=True,
-                                              timeout=timeout)
+                                              timeout=timeout))
                     except ntp.packet.SyncException as e:
                         log(str(e))
                         continue
+                for r in results:
+                    try:
+                        if callable(r):
+                            returned += r()
+                    except ntp.packet.SyncException as e:
+                        log(str(e))
+                        continue
+
                 for server in arguments:
                     try:
                         returned += queryhost(server=server,
@@ -432,7 +458,8 @@ if __name__ == '__main__':
             pkt = returned[0]
             if debug:
                 # print(repr(pkt))
-                def hexstamp(n):
+                def hexstamp(pn):
+                    n = ntp.packet.SyncPacket.posix_to_ntp(pn)
                     return "%08x.%08x" % (n >> 32, n & 0x00000000ffffffff)
                 print("org t1: %s rec t2: %s"
                       % (hexstamp(pkt.t1()), hexstamp(pkt.t2())))
@@ -455,7 +482,11 @@ if __name__ == '__main__':
             if adjusted:
                 rc = ntp.ntpc.step_systime(offset)
             elif slew:
-                rc = ntp.ntpc.adj_systime(offset)
+                if abs(offset) <= steplimit:
+                    rc = ntp.ntpc.adj_systime(offset)
+                else:
+                    log("Adjustment of %fms not done (step limit = %fms)" %
+                        (1000*offset, 1000*steplimit))
             if rc:
                 raise SystemExit(0)
             else:


### PR DESCRIPTION
The most important change is sorting by offset.  This provides greater stability to those who run the client from cron.  I used to see logs like this:
```log
Sep  8 00:00:02 14 north cron_sntp: Time offset= +0.022322; +/- 0.006090 pool.ntp.org 80.88.90.14 s2 no-leap
Sep  8 00:30:01 14 north cron_sntp: Time offset= +0.023896; +/- 0.013601 pool.ntp.org 85.199.214.99 s1 no-leap
Sep  8 01:00:02 14 north cron_sntp: Time offset= +0.023296; +/- 0.006103 pool.ntp.org 80.88.90.14 s2 no-leap
Sep  8 01:30:09 10 north cron_sntp: CLOCK: time stepped by 2.528809, rtc=0
Sep  8 01:30:09 10 north cron_sntp: Time offset= +2.528809; +/- 2.503697 pool.ntp.org 185.19.184.35 s2 no-leap
Sep  8 02:00:06 14 north cron_sntp: Time offset= +0.029088; +/- 2.508656 pool.ntp.org 185.157.229.254 s2 no-leap
Sep  8 02:29:59 10 north cron_sntp: CLOCK: time stepped by -2.484406, rtc=0
Sep  8 02:29:59 10 north cron_sntp: Time offset= -2.484406; +/- 0.001504 pool.ntp.org 162.159.200.123 s3 no-leap
Sep  8 03:00:03 14 north cron_sntp: Time offset= +0.020611; +/- 0.013354 pool.ntp.org 93.94.88.51 s3 no-leap
Sep  8 03:30:02 14 north cron_sntp: Time offset= +0.027958; +/- 0.001613 pool.ntp.org 162.159.200.1 s3 no-leap
```
The new sorting gives less importance to the stratum and almost none to the distance.  In addition, option -M can be given even without -S, so that I now have logs like so:
```log
Sep 13 23:30:07 14 north cron_sntp: Time offset= +0.019521; +/- 0.007942 pool.ntp.org 162.159.200.123 s3 no-leap
Sep 14 00:00:07 14 north cron_sntp: Time offset= +0.027320; +/- 0.001725 pool.ntp.org 185.19.184.35 s2 no-leap
Sep 14 00:30:13 10 north cron_sntp: Time offset= +3.520828; +/- 3.504331 pool.ntp.org 162.159.200.123 s3 no-leap
Sep 14 00:30:13 10 north cron_sntp: ntpdig: Adjustment of 3520.828485ms not done (step limit = 256.000000ms)
Sep 14 01:00:08 14 north cron_sntp: Time offset= +0.037637; +/- 0.001469 pool.ntp.org 162.159.200.1 s3 no-leap
Sep 14 01:30:12 10 north cron_sntp: Time offset= +3.524691; +/- 3.515389 pool.ntp.org 93.94.88.50 s2 no-leap
Sep 14 01:30:12 10 north cron_sntp: ntpdig: Adjustment of 3524.691105ms not done (step limit = 256.000000ms)
Sep 14 02:00:08 14 north cron_sntp: Time offset= +0.041852; +/- 0.012898 pool.ntp.org 93.94.88.50 s2 no-leap
Sep 14 02:30:07 14 north cron_sntp: Time offset= +0.016553; +/- 0.001517 pool.ntp.org 162.159.200.123 s3 no-leap
Sep 14 03:00:08 14 north cron_sntp: Time offset= +0.025660; +/- 0.006478 pool.ntp.org 185.157.229.254 s2 no-leap
```

Besides, this pull request includes a number of minor fixes:

- Using concurrent hosts now works as intended, collecting replies after all queries,
- querying localhost only if neither argument nor concurrent hosts given,
- default gap is 2 seconds, as the man page says,
- debug level 2 for sleeping, dumps moved to level 3,
- use sender address and server name in read_append() (only affects debug output),
- display all replies at debug level 1, and
- steplimit displayed in help and accepting decimals.